### PR TITLE
only validate secret if we have access to API / default NS exists

### DIFF
--- a/charts/collectorset-controller/templates/_helpers.tpl
+++ b/charts/collectorset-controller/templates/_helpers.tpl
@@ -67,10 +67,19 @@ Argus proxy details or not, for this we're using Lookup function in helm.
 */}}
 
 {{- define "lm-credentials-and-proxy-details" -}}
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.global.userDefinedSecret) | default dict }}
-{{- $secretData := (get $secretObj "data") | default dict }}
-{{- $data := dict "root" . "secretdata" $secretData }}
-{{- include "lmutil.validate-user-provided-secret" $data }}
+  {{- $secName   := .Values.global.userDefinedSecret }}
+  {{- /* look up the always-present default namespace */}}
+  {{- $defaultNS := lookup "v1" "Namespace" "" "default" }}
+
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secName) | default dict }}
+  {{- $secretData := $secretObj.data | default dict }}
+  {{- if $defaultNS }}
+    {{- /* real install or --dry-run=server: now validate the user secret */}}
+    {{- include "lmutil.validate-user-provided-secret" (dict "root" . "secretdata" $secretData) }}
+  {{- else }}
+    {{- /* client-side --dry-run: lookup returned empty, so skip validation */}}
+  {{- end }}
+{{- end }}
 - name: ACCESS_ID
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
This change retrieves the default namespace, and only if that is successful does it validate the user defined secret.  During a dry-run (without the server option), the Kubernetes API is not consulted, and any "lookup" values are empty.  During an actual install, the default namespace will be found, and the secret validated.  Corner-case is if someone actually deletes the default namespace on their cluster, if that is even possible, in which case the install should still work, but the secret will not be validated.
